### PR TITLE
abort if working directory contains unstaged changes

### DIFF
--- a/xyz
+++ b/xyz
@@ -103,6 +103,9 @@ esac
 [[ $(git rev-parse --abbrev-ref HEAD) == $branch ]] ||
   (echo "Current branch does not match specified --branch" >&2 ; exit 1)
 
+git diff-files --quiet ||
+  (echo "Working directory contains unstaged changes" >&2 ; exit 1)
+
 name=$(node -p "require('./package.json').name" 2>/dev/null) ||
   (echo "Cannot read package name" >&2 ; exit 1)
 


### PR DESCRIPTION
It's important that we continue to include staged changes in the release; _unstaged_ changes should be staged or reverted before publishing.

Should we go a step further and abort if there are untracked files, to prevent their inclusion in the tarball?
