### PR TITLE
Verify module before releasing

### DIFF
--- a/xyz
+++ b/xyz
@@ -133,6 +133,12 @@ run() {
   fi
 }
 
+# Prune before running tests to catch dependencies that have been
+# installed but not specified in the project's `package.json` file.
+
+run "npm prune"
+run "npm test"
+
 for script in "${scripts[@]}" ; do
   [[ $script == /* ]] || script="$(pwd)/$script"
   run "VERSION=$next_version PREVIOUS_VERSION=$version '$script'"


### PR DESCRIPTION
Prune untracked depedencies and run project tests at the beginning of
the release project. Enable this behavior by default and allow opting
out through an explicit `--no-verify` command line flag.
