### PR TITLE
Don't touch bower version

### DIFF
--- a/xyz
+++ b/xyz
@@ -9,7 +9,7 @@ This involves updating the version number in package.json, committing this
 change (along with any staged changes), tagging the commit, pushing to the
 remote git repository, and finally publishing to the public npm registry.
 
-If present, bower.json and component.json are updated along with package.json.
+If present, component.json is updated along with package.json.
 
 Options:
 
@@ -155,7 +155,6 @@ inc() {
 }
 
 inc package.json
-inc bower.json
 inc component.json
 
 run "git commit --message '$message'"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3 this is useless. I'm in the process of making PR's to every bower repo to get that removed forever

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property