### PR TITLE
Add --atomic flag to git push

### DIFF
--- a/xyz
+++ b/xyz
@@ -159,6 +159,6 @@ inc component.json
 
 run "git commit --message '$message'"
 run "git tag --annotate '$tag' --message '$message'"
-run "git push '$repo' 'refs/heads/$branch' 'refs/tags/$tag'"
+run "git push --atomic '$repo' 'refs/heads/$branch' 'refs/tags/$tag'"
 
 run "npm publish"


### PR DESCRIPTION
This flag makes sure that either both the branch and the tag gets pushed, or (in the case of an error) none of them gets pushed.

Fixes #18