### PR TITLE
Add detection of private packages and don't publish them to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Several things will happen if one elects to continue:
     git commit --message 'Version 0.6.1'
     git tag --annotate 'v0.6.1' --message 'Version 0.6.1'
     git push origin 'refs/heads/master' 'refs/tags/v0.6.1'
-    npm publish
+    npm publish # Only for non-private packages.
 
 xyz accepts several optional arguments, described in the help text:
 

--- a/xyz
+++ b/xyz
@@ -164,4 +164,4 @@ run "git commit --message '$message'"
 run "git tag --annotate '$tag' --message '$message'"
 run "git push --atomic '$repo' 'refs/heads/$branch' 'refs/tags/$tag'"
 
-run "npm publish"
+node -e 'process.exit(require("./package.json").private === true ? 1 : 0)' && run "npm publish"


### PR DESCRIPTION
Closes #28
Again, tested with `--dry-run` and does indeed not output the `npm publish` line when `private` is set to `true` in **package.json**.