### PR TITLE
remove support for Component

### DIFF
--- a/xyz
+++ b/xyz
@@ -9,8 +9,6 @@ This involves updating the version number in package.json, committing this
 change (along with any staged changes), tagging the commit, pushing to the
 remote git repository, and finally publishing to the public npm registry.
 
-If present, component.json is updated along with package.json.
-
 Options:
 
 -b --branch <name>
@@ -163,7 +161,6 @@ inc() {
 }
 
 inc package.json
-inc component.json
 
 run "git commit$([[ $edit == true ]] && printf ' --edit') --message '$message'"
 run "git tag --annotate '$tag' --message '$message'"


### PR DESCRIPTION
Component was deprecated more than a year ago, according to componentjs/component#639. I think we should remove support for __component.json__. Do you agree, @michaelficarra? If so I will merge this pull request and `make release-major`.
