### PR TITLE
Fix a failure that occurs when CDPATH is set

### DIFF
--- a/xyz
+++ b/xyz
@@ -55,6 +55,7 @@ Options:
 "
 
 # http://stackoverflow.com/a/246128/312785
+unset CDPATH
 path="${BASH_SOURCE[0]}"
 while [ -h "$path" ] ; do
   dir="$(cd -P "$(dirname "$path")" && pwd)"


### PR DESCRIPTION
I’ve noticed an issue that appears when $CDPATH is set. Everything works fine if I call the executable with a leading `./`:

```
~/Code/testing-xyz $ ./node_modules/.bin/xyz
Current version is 1.0.0. Press [enter] to publish testing-xyz@1.0.1.
```

However, this fails:

```
~/Code/testing-xyz $ node_modules/.bin/xyz
node_modules/.bin/xyz: line 64: cd: ./node_modules/.bin
/Users/jdudek/Code/testing-xyz/node_modules/.bin/../xyz: No such file or directory
```

I was able to find out this is caused by the presence of $CDPATH, which I set as follows:

```
~/Code/testing-xyz $ echo $CDPATH
.:/Users/jdudek/Code
```

Unsetting the variable fixes the problem:

```
~/Code/testing-xyz $ CDPATH="" node_modules/.bin/xyz
Current version is 1.0.0. Press [enter] to publish testing-xyz@1.0.1.
```

(BTW huge thanks for including the link to Stack Overflow thread—I can’t imagine how many hours I’d have to spend to find out the cause myself!)

I think it might be a case where $CDPATH causes cd to print additional output. Adding `echo $dir` shows
```
./node_modules/.bin /Users/jdudek/Code/testing-xyz/node_modules/.bin
```
in the broken case and just
```
node_modules/.bin
```
in the correct case. I did not investigate it further and assumed it’s safe to just unset $CDPATH—following the advice from the Stack Overflow thread mentioned above.