### PR TITLE
readme: document use of --publish-command with npm's --otp option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELLCHECK = shellcheck
-XYZ = ./xyz --repo git@github.com:davidchambers/xyz.git
+XYZ = ./xyz --repo git@github.com:davidchambers/xyz.git --publish-command 'read -r -p "One-time password: " && npm publish --otp "$$REPLY"'
 
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ release-major release-minor release-patch:
 ```console
 $ make release-minor
 ```
+
+### Two-factor authentication
+
+When [two-factor authentication][1] is enabled in __auth-and-writes__ mode,
+npm requires a one-time password when publishing a new version of a package.
+The `--publish-command` option can be used to prompt for a one-time password:
+
+```bash
+--publish-command 'read -r -p "One-time password: " && npm publish --otp "$REPLY"'
+```
+
+
+[1]: https://docs.npmjs.com/getting-started/using-two-factor-authentication


### PR DESCRIPTION
I don't yet have a clear mental model of npm's [two-factor authentication][1]. I have enabled it for my account but I don't know whether it:

  - requires *me* to provide a one-time password when publishing *any* package; or
  - requires *anyone* publishing a new version of one of *my* packages to provide a one-time password.

I believe the former to be the case. If so, it's possible that some but not all of a project's maintainers require `--otp`. Hopefully the value of the `--otp` option is ignored when not required. I'll investigate.


[1]: https://docs.npmjs.com/getting-started/using-two-factor-authentication
