### PR TITLE
respect --publish-command for private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Several things will happen if one elects to continue:
     git commit --message 'Version 0.6.1'
     git tag --annotate 'v0.6.1' --message 'Version 0.6.1'
     git push --atomic 'origin' 'refs/heads/master' 'refs/tags/v0.6.1'
-    npm publish # Only for non-private packages.
+    VERSION=0.6.1 PREVIOUS_VERSION=0.6.0 npm publish
 
 xyz accepts several optional arguments, described in the help text:
 

--- a/xyz
+++ b/xyz
@@ -32,8 +32,10 @@ Options:
         'Version X.Y.Z' is assumed if this option is omitted.
 
    --publish-command <command>
-        Specify command to run as final step. 'npm publish' is
-        assumed if this option is omitted.
+        Specify the command to be run to publish the package. It may refer
+        to the VERSION and PREVIOUS_VERSION environment variables. A no-op
+        command (':' or 'true') prevents the package from being published
+        to a registry. 'npm publish' is assumed if this option is omitted.
 
 -r --repo <repository>
         Specify the remote repository to which to 'git push'.
@@ -169,4 +171,4 @@ run "git commit$([[ $edit == true ]] && printf ' --edit') --message '$message'"
 run "git tag --annotate '$tag' --message '$message'"
 run "git push --atomic '$repo' 'refs/heads/$branch' 'refs/tags/$tag'"
 
-node -e 'process.exit(require("./package.json").private === true ? 1 : 0)' && run "$publish_command"
+run "VERSION=$next_version PREVIOUS_VERSION=$version $publish_command"


### PR DESCRIPTION
Closes #37

Commit message:

> This commit also exposes `VERSION` and `PREVIOUS_VERSION` to commands.
