### PR TITLE
use "$@" in ‘run’ function to simplify quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ steps with a single command:
 
 Several things will happen if one elects to continue:
 
-    VERSION=0.6.1 node -e "
-      var pkg = require('./package.json');
+    env VERSION=0.6.1 node -e '
+      var pkg = require("./package.json");
       pkg.version = process.env.VERSION;
-      fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-    "
+      fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+    '
     git add package.json
     git commit --message 'Version 0.6.1'
-    git tag --annotate 'v0.6.1' --message 'Version 0.6.1'
-    git push --atomic 'origin' 'refs/heads/master' 'refs/tags/v0.6.1'
-    VERSION=0.6.1 PREVIOUS_VERSION=0.6.0 npm publish
+    git tag --annotate v0.6.1 --message 'Version 0.6.1'
+    git push --atomic origin refs/heads/master refs/tags/v0.6.1
+    env VERSION=0.6.1 PREVIOUS_VERSION=0.6.0 bash -c 'npm publish'
 
 xyz accepts several optional arguments, described in the help text:
 

--- a/xyz
+++ b/xyz
@@ -143,32 +143,43 @@ read -r -s  # suppress user input
 echo        # output \n since [enter] output was suppressed
 
 run() {
-  echo "$1"
+  local arg
+  for arg ; do
+    if [[ $(printf "%q" "$arg") == "$arg" ]] ; then
+      printf "%s " "$arg"
+    else
+      printf "'%s' " "${arg//"'"/"'"'"'"'"'"'"'"}"
+    fi
+  done
+  echo
   if [[ $dry_run == false ]] ; then
-    eval "$1"
+    "$@"
   fi
 }
 
 # Prune before running tests to catch dependencies that have been
 # installed but not specified in the project's `package.json` file.
 
-run "npm prune"
-run "npm test"
+run npm prune
+run npm test
 
 for script in "${scripts[@]}" ; do
   [[ $script == /* ]] || script="$(pwd)/$script"
-  run "VERSION=$next_version PREVIOUS_VERSION=$version '$script'"
+  run env VERSION="$next_version" PREVIOUS_VERSION="$version" "$script"
 done
 
-run "VERSION=$next_version node -e "'"'"
-  var pkg = require('./package.json');
+run env VERSION="$next_version" node -e '
+  var pkg = require("./package.json");
   pkg.version = process.env.VERSION;
-  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-"'"'
-run "git add package.json"
+  fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+'
+run git add package.json
 
-run "git commit$([[ $edit == true ]] && printf ' --edit') --message '$message'"
-run "git tag --annotate '$tag' --message '$message'"
-run "git push --atomic '$repo' 'refs/heads/$branch' 'refs/tags/$tag'"
+declare -a commit_options=(--message "$message")
+[[ $edit == true ]] && commit_options+=(--edit)
+run git commit "${commit_options[@]}"
+run git tag --annotate "$tag" --message "$message"
+run git push --atomic "$repo" "refs/heads/$branch" "refs/tags/$tag"
 
-run "VERSION=$next_version PREVIOUS_VERSION=$version $publish_command"
+run env VERSION="$next_version" PREVIOUS_VERSION="$version" \
+        bash -c "$publish_command"


### PR DESCRIPTION
In addition to obviating the need for `'"'"'` in the source code, this commit removes unnecessary quoting from the printed commands. :)
