### PR TITLE
Use git diff instead of git diff-files

### DIFF
--- a/xyz
+++ b/xyz
@@ -114,7 +114,7 @@ esac
 [[ $(git rev-parse --abbrev-ref HEAD) == "$branch" ]] ||
   (echo "Current branch does not match specified --branch" >&2 ; exit 1)
 
-git diff-files --quiet ||
+git diff --quiet ||
   (echo "Working directory contains unstaged changes" >&2 ; exit 1)
 
 name=$(node -p "require('./package.json').name" 2>/dev/null) ||


### PR DESCRIPTION
`git diff-files` will show a diff even if the file's contents have not been changed, but it has been touched in the same bash process as `xyz`. I'm not sure if there is a specific reason we are using `diff-files` here in lieu of `diff`, as far as I know the functionality should be the same here.

```sh
22:50 ~/github.com/xyz (nt-use-diff *)
$ git status
On branch nt-use-diff
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   xyz

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff --quiet; echo $?
1

22:50 ~/github.com/xyz (nt-use-diff *)
$ git diff-files --quiet; echo $?
1

22:50 ~/github.com/xyz (nt-use-diff *)
$ git add .

22:51 ~/github.com/xyz (nt-use-diff +)
$ git diff-files --quiet; echo $?
0

22:51 ~/github.com/xyz (nt-use-diff +)
$ git diff --quiet; echo $?
0

22:51 ~/github.com/xyz (nt-use-diff +)
$ touch xyz && git diff-files --quiet; echo $?
1

22:51 ~/github.com/xyz (nt-use-diff +)
$ touch xyz && git diff --quiet; echo $?
0

22:51 ~/github.com/xyz (nt-use-diff +)
$ echo "foo" >> xyz

22:53 ~/github.com/xyz (nt-use-diff *+)
$ git diff --quiet; echo $?
1

22:53 ~/github.com/xyz (nt-use-diff *+)
$ git diff-files --quiet; echo $?
1
```