### PR TITLE
implement semver --increment to remove dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,5 @@
     "type": "git",
     "url": "git://github.com/davidchambers/xyz.git"
   },
-  "dependencies": {
-    "semver": "5.3.x"
-  },
-  "bundledDependencies": [
-    "semver"
-  ]
+  "dependencies": {}
 }

--- a/xyz
+++ b/xyz
@@ -31,6 +31,11 @@ Options:
         'X.Y.Z' acts as a placeholder for the version number.
         'Version X.Y.Z' is assumed if this option is omitted.
 
+   --prerelease-label <label>
+        Specify the label to be used in the version number when publishing
+        a pre-release version (e.g. 'beta' is the label in '2.0.0-beta.0').
+        'rc' is assumed if this option is omitted.
+
    --publish-command <command>
         Specify the command to be run to publish the package. It may refer
         to the VERSION and PREVIOUS_VERSION environment variables. A no-op
@@ -60,27 +65,70 @@ Options:
         Print xyz's version number and exit.
 "
 
-# http://stackoverflow.com/a/246128/312785
-unset CDPATH
-path="${BASH_SOURCE[0]}"
-while [ -h "$path" ] ; do
-  dir="$(cd -P "$(dirname "$path")" && pwd)"
-  path="$(readlink "$path")"
-  [[ $path == /* ]] || path="$dir/$path"
-done
-dir="$(cd -P "$(dirname "$path")" && pwd)"
+inc() {
+  local prerelease_label="$1" increment="$2" version="$3"
+  local number='0|[1-9][0-9]*'
+  local part="$number|[-0-9A-Za-z]+"
+  local pattern="^($number)[.]($number)[.]($number)(-(($part)([.]($part))*))?$"
+  if ! [[ $version =~ $pattern ]] ; then
+    printf 'Invalid version: %s\n' "$version" >&2
+    return 1
+  fi
+  local -i x=${BASH_REMATCH[1]}
+  local -i y=${BASH_REMATCH[2]}
+  local -i z=${BASH_REMATCH[3]}
+  local qual=${BASH_REMATCH[5]}
+
+  local -a parts=("$prerelease_label" 0)
+  case $increment in
+    major)  (( y + z == 0 )) && [[ -n $qual ]] || x+=1 ; y=0 ; z=0 ;;
+    minor)      (( z == 0 )) && [[ -n $qual ]] || y+=1 ; z=0 ;;
+    patch)                      [[ -n $qual ]] || z+=1 ;;
+    premajor)                                     x+=1 ; y=0 ; z=0 ;;
+    preminor)                                     y+=1 ; z=0 ;;
+    prepatch)                                     z+=1 ;;
+    prerelease)
+      case ${BASH_REMATCH[6]} in
+        '') z+=1 ;;
+        $prerelease_label)
+          local idx
+          local -a xs
+          IFS=. read -r -a xs <<<"$qual"
+          for (( idx = ${#xs[@]} - 1 ; idx > 0 ; idx -= 1 )) ; do
+            pattern="^($number)$"
+            if [[ ${xs[idx]} =~ $pattern ]] ; then
+              parts=(${xs[@]})
+              (( parts[idx] += 1 ))
+              break
+            fi
+          done
+      esac
+      ;;
+    *)
+      echo "Invalid --increment" >&2
+      return 1
+  esac
+
+  version="$x.$y.$z"
+  if [[ $increment =~ ^pre ]] ; then
+    join() { local IFS=. ; echo "$*" ; }
+    version+="-$(join "${parts[@]}")"
+  fi
+  printf %s "$version"
+}
 
 branch=master
 edit=false
 increment=patch
 message_template='Version X.Y.Z'
+prerelease_label=rc
 publish_command='npm publish'
 repo=origin
 declare -a scripts
 tag_template=vX.Y.Z
 dry_run=false
 
-while (($# > 0)) ; do
+while (( $# > 0 )) ; do
   option="$1"
   shift
 
@@ -90,28 +138,24 @@ while (($# > 0)) ; do
       exit
       ;;
     -v|--version)
-      node -p "require('$dir/package.json').version"
+      node -p 'require("xyz/package.json").version'
       exit
       ;;
-    -b|--branch)          branch="$1"           ; shift ;;
-    -e|--edit)            edit=true             ;;
-    -i|--increment)       increment="$1"        ; shift ;;
-    -m|--message)         message_template="$1" ; shift ;;
-       --publish-command) publish_command="$1"  ; shift ;;
-    -r|--repo)            repo="$1"             ; shift ;;
-    -s|--script)          scripts+=("$1")       ; shift ;;
-    -t|--tag)             tag_template="$1"     ; shift ;;
-       --dry-run)         dry_run=true          ;;
+    -b|--branch)            branch="$1"           ; shift ;;
+    -e|--edit)              edit=true             ;;
+    -i|--increment)         increment="$1"        ; shift ;;
+    -m|--message)           message_template="$1" ; shift ;;
+       --prerelease-label)  prerelease_label="$1" ; shift ;;
+       --publish-command)   publish_command="$1"  ; shift ;;
+    -r|--repo)              repo="$1"             ; shift ;;
+    -s|--script)            scripts+=("$1")       ; shift ;;
+    -t|--tag)               tag_template="$1"     ; shift ;;
+       --dry-run)           dry_run=true          ;;
     *)
       echo "Unrecognized option $option" >&2
       exit 1
   esac
 done
-
-case "$increment" in
-  major|minor|patch|premajor|preminor|prepatch|prerelease) ;;
-  *) echo "Invalid --increment" >&2 ; exit 1 ;;
-esac
 
 [[ $(git rev-parse --abbrev-ref HEAD) == "$branch" ]] ||
   (echo "Current branch does not match specified --branch" >&2 ; exit 1)
@@ -125,8 +169,7 @@ name=$(node -p "require('./package.json').name" 2>/dev/null) ||
 version=$(node -p "require('./package.json').version" 2>/dev/null) ||
   (echo "Cannot read package version" >&2 ; exit 1)
 
-next_version=$("$dir/node_modules/.bin/semver" -i "$increment" "$version") ||
-  (echo "Cannot increment version number" >&2 ; exit 1)
+next_version=$(inc "$prerelease_label" "$increment" "$version")
 
 message="${message_template//X.Y.Z/$next_version}"
 tag="${tag_template//X.Y.Z/$next_version}"


### PR DESCRIPTION
I've wanted to do this for some time. The complexity of the code we add to the project by removing the dependency is offset by the incidental complexity we remove from the project by doing so. This change inadvertently closes #2 as we no longer need to determine our location on the file system.

We have no test suite, in part because I'd like to keep the source code in a single file which makes it difficult to test individual functions without triggering the script's side effects. I wrote a throwaway program to assert that the new `inc` function produces the same results as `semver --increment` (using `semver@5.3.0`) for 1792 inputs. Here's the test matrix I used:

```bash
for x in 0 1 9 10 ; do
  for y in 0 1 9 10 ; do
    for z in 0 1 9 10 ; do
      for suff in '' -rc.0 -rc.11.22.33.xx -beta.0 ; do
        version="$x.$y.$z$suff"
        for increment in major minor patch premajor preminor prepatch prerelease ; do
          # compare `inc` with `semver --increment`
        done
      done
    done
  done
done
```

I *think* this covers all the edge cases. Please let me know if you think of one I missed. :)
