### PR TITLE
set -euf -o pipefail

### DIFF
--- a/xyz
+++ b/xyz
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euf -o pipefail
 
 usage="
 Usage: xyz [options]
@@ -220,7 +220,7 @@ run npm prune
 run npm test
 
 for script in "${scripts[@]}" ; do
-  [[ $script == /* ]] || script="$(pwd)/$script"
+  [[ $script =~ ^/ ]] || script="$(pwd)/$script"
   run env VERSION="$next_version" PREVIOUS_VERSION="$version" "$script"
 done
 


### PR DESCRIPTION
`set -euf -o pipefail` is equivalent to:

```bash
set -o errexit      # Exit immediately if a command exits with a non-zero status.

set -o nounset      # Treat unset variables as an error when substituting.

set -o noglob       # Disable file name generation (globbing).

set -o pipefail     # The return value of a pipeline is the status of
                    # the last command to exit with a non-zero status,
                    # or zero if no command exited with a non-zero status.
```

We already have `errexit` enabled. ShellCheck asserts statically what `nounset` checks at run time, so this option should be safe to enable. We don't currently use any globbing or piping, so enabling `noglob` and `pipefail` should not change the behaviour of the program.
