### PR TITLE
package.json: specify "files"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-/.npmignore
-/Makefile
-/npm-debug.log

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "release",
     "tool"
   ],
+  "files": [
+    "/LICENSE",
+    "/README.md",
+    "/package.json",
+    "/xyz"
+  ],
   "bin": "./xyz",
   "homepage": "https://github.com/davidchambers/xyz",
   "bugs": "https://github.com/davidchambers/xyz/issues",


### PR DESCRIPTION
Specifying the files we wish to *in*clude is preferable as there are only four files and it's unlikely that we will one day wish to include additional files (whereas the list of files we wish to exclude may change).
