### PR TITLE
travis: use pre-installed version of ShellCheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,2 @@
 language: bash
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
 script: make lint


### PR DESCRIPTION
<https://github.com/koalaman/shellcheck#travis-ci>:

> Travis CI has now integrated ShellCheck by default, so you don't need to manually install it.
