### PR TITLE
remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: bash
-script: make lint


### PR DESCRIPTION
Travis CI has not worked well for me for several years; I have migrated other repositories to GitHub Actions.

Setting up GitHub Actions for this repository would provide little value, for several reasons:

  - changes are infrequent;
  - all pull requests are written or reviewed by me;
  - the only check GitHub Actions would perform is `shellcheck xyz`, which I run habitually; and
  - there are no automated tests, so all changes must be scrutinized and manually tested.

In summary, a ✘ would draw attention to a potential issue, but a ✔︎ would say very little about whether a change is sound.
