### PR TITLE
abort with informative message if Bash version is inadequate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Several things will happen if one elects to continue:
     git push --atomic origin refs/heads/master refs/tags/v0.6.1
     env VERSION=0.6.1 PREVIOUS_VERSION=0.6.0 bash -c 'npm publish'
 
-_**macOS Mojave**, released in 2018, provides a version of Bash from 2007.
-xyz uses a feature added in Bash 4, released in 2009. macOS users should run
-`brew install bash` to install a compatible Bash version._
+> [!IMPORTANT]
+>
+> **macOS Mojave**, released in 2018, provides a version of Bash from 2007.
+> xyz uses a feature added in Bash 4, released in 2009. macOS users should run
+> `brew install bash` to install a compatible Bash version.
 
 ## Usage
 

--- a/xyz
+++ b/xyz
@@ -71,7 +71,7 @@ Options:
 "
 
 abort() {
-  printf '%s\n' "$1" >&2
+  printf '%s\n' "$@" >&2
   exit 1
 }
 
@@ -126,6 +126,24 @@ inc() {
   fi
   printf %s "$version"
 }
+
+if type tput &>/dev/null ; then
+  bold=$(tput bold)
+  smul=$(tput smul)
+  rmul=$(tput rmul)
+  reset=$(tput sgr0)
+fi
+
+check_bash_version() {
+  if (( BASH_VERSINFO[0] < 4 )) ; then
+    local xyz
+    xyz="$(IFS=.; echo "${BASH_VERSINFO[*]:0:3}")"
+    abort \
+      "Inadequate Bash version: ${bold}${xyz}${reset} < ${bold}4.0.0${reset}" \
+      "${smul}https://github.com/davidchambers/xyz/issues/51${rmul}"
+  fi
+}
+check_bash_version
 
 declare -A options=(
   [branch]=master
@@ -200,11 +218,6 @@ next_version=$(inc "${options[prerelease-label]}" \
 
 message="${options[message]//X.Y.Z/$next_version}"
 tag="${options[tag]//X.Y.Z/$next_version}"
-
-if type tput &>/dev/null ; then
-  bold=$(tput bold)
-  reset=$(tput sgr0)
-fi
 
 printf "Current version is %s. Press [enter] to publish %s." \
        "${bold}${version}${reset}" \


### PR DESCRIPTION
Closes #59

This pull request improves the experience for those with an inadequate Bash version. Instead of a misleading error message about an unbound variable they will now see an informative error message:

<pre>$ <b>xyz</b>
Inadequate Bash version: <b>3.2.57</b> &lt; <b>4.0.0</b>
<ins>https://github.com/davidchambers/xyz/issues/51</ins>

$ <b>echo $?</b>
1
</pre>
