### PR TITLE
quote variable in case pattern

### DIFF
--- a/xyz
+++ b/xyz
@@ -100,7 +100,7 @@ inc() {
     prerelease)
       case ${BASH_REMATCH[6]} in
         '') z+=1 ;;
-        $prerelease_label)
+        "$prerelease_label")
           local idx
           local -a xs
           IFS=. read -r -a xs <<<"$qual"


### PR DESCRIPTION
This pull request effects a change suggested by [SC2254][1], a rule added to ShellCheck in [v0.7.1][2].

I have confirmed that `--increment prerelease` still works as expected.


[1]: https://www.shellcheck.net/wiki/SC2254
[2]: https://github.com/koalaman/shellcheck/blob/v0.7.1/CHANGELOG.md?plain=1#L11
