### PR TITLE
change default `--branch` value from `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Several things will happen if one elects to continue:
     git add package.json
     git commit --message 'Version 0.6.1'
     git tag --annotate v0.6.1 --message 'Version 0.6.1'
-    git push --atomic origin refs/heads/master refs/tags/v0.6.1
+    git push --atomic origin refs/heads/main refs/tags/v0.6.1
     env VERSION=0.6.1 PREVIOUS_VERSION=0.6.0 bash -c 'npm publish'
 
 > [!IMPORTANT]
@@ -41,7 +41,7 @@ Several things will happen if one elects to continue:
     -b --branch <name>
             Specify the branch from which new versions must be published.
             xyz aborts if run from any other branch to prevent accidental
-            publication of feature branches. 'master' is assumed if this
+            publication of feature branches. 'main' is assumed if this
             option is omitted.
 
     -e --edit

--- a/xyz
+++ b/xyz
@@ -14,7 +14,7 @@ Options:
 -b --branch <name>
         Specify the branch from which new versions must be published.
         xyz aborts if run from any other branch to prevent accidental
-        publication of feature branches. 'master' is assumed if this
+        publication of feature branches. 'main' is assumed if this
         option is omitted.
 
 -e --edit
@@ -146,7 +146,7 @@ check_bash_version() {
 check_bash_version
 
 declare -A options=(
-  [branch]=master
+  [branch]=main
   [dry-run]=false
   [edit]=false
   [increment]=patch


### PR DESCRIPTION
> [!IMPORTANT]
>
> Add `--branch master` to your release command when upgrading if you currently rely on the old default value.

This is similar to the change we made in sanctuary-js/sanctuary-scripts#54.

I have already renamed this repository's default branch `main`; if for some reason we decide not to merge this pull request we will need to add `--branch main` to the makefile.

Are you in favour of this change?
